### PR TITLE
Refactor tile types and terrain costs

### DIFF
--- a/scripts/Data/terrain_costs.gd
+++ b/scripts/Data/terrain_costs.gd
@@ -1,0 +1,12 @@
+const TERRAIN_COSTS: Dictionary = {
+    "fertile": 1.5,
+    "grain": 1.5,
+    "forest": 3.0,
+    "rural_building": 1.0,
+    "road": 1.0,
+    "mine": 2.0,
+    "mountain": 4.0,
+    "swamp": 2.5,
+    "water": 999.0,
+    "unknown": 2.0,
+}

--- a/scripts/Objects/city.gd
+++ b/scripts/Objects/city.gd
@@ -77,18 +77,7 @@ var extraction_initialized = false
 static var selected_city: City = null
 
 # Terrain costs for trade routes
-const TERRAIN_COSTS: Dictionary = {
-	"fertile": 1.5,
-	"grain": 1.5,
-	"forest": 3.0,
-	"rural_building": 1.0,
-	"road": 1.0,
-	"mine": 2.0,
-	"mountain": 4.0,
-	"swamp": 2.5,
-	"water": 999.0,  # Effectively impassable
-	"unknown": 0
-}
+const TerrainCosts = preload("res://scripts/Data/terrain_costs.gd")
 
 func _ready() -> void:
 	await get_tree().process_frame
@@ -365,7 +354,7 @@ func _get_terrain_cost(pos: Vector2i) -> float:
 	for tile in get_tree().get_nodes_in_group("tiles"):
 		if tile.global_position.distance_to(world_pos) < tile_size / 2:
 			return tile.get_terrain_cost()
-	return TERRAIN_COSTS["unknown"]
+       return TerrainCosts.TERRAIN_COSTS["unknown"]
 
 func _calculate_path_cost(path: Array[Vector2i]) -> float:
 	var cost = 0.0

--- a/scripts/Objects/tiles/fertile_tile.gd
+++ b/scripts/Objects/tiles/fertile_tile.gd
@@ -1,5 +1,3 @@
 extends Tile
 
-func _ready() -> void:
-	super._ready()
-	_set_tile_type("fertile")
+@export var tile_type: String = "fertile"

--- a/scripts/Objects/tiles/forest_tile.gd
+++ b/scripts/Objects/tiles/forest_tile.gd
@@ -1,5 +1,3 @@
 extends Tile
 
-func _ready() -> void:
-	super._ready()
-	_set_tile_type("forest")
+@export var tile_type: String = "forest"

--- a/scripts/Objects/tiles/grain_tile.gd
+++ b/scripts/Objects/tiles/grain_tile.gd
@@ -1,5 +1,3 @@
 extends Tile
 
-func _ready() -> void:
-	super._ready()
-	_set_tile_type("grain")
+@export var tile_type: String = "grain"

--- a/scripts/Objects/tiles/mine_tile.gd
+++ b/scripts/Objects/tiles/mine_tile.gd
@@ -1,5 +1,3 @@
 extends Tile
 
-func _ready() -> void:
-	super._ready()
-	_set_tile_type("mine")
+@export var tile_type: String = "mine"

--- a/scripts/Objects/tiles/mountain_tile.gd
+++ b/scripts/Objects/tiles/mountain_tile.gd
@@ -1,6 +1,4 @@
 extends Tile
 
-func _ready() -> void:
-	super._ready()
-	_set_tile_type("mountain")
+@export var tile_type: String = "mountain"
 	

--- a/scripts/Objects/tiles/rural_building_tile.gd
+++ b/scripts/Objects/tiles/rural_building_tile.gd
@@ -1,5 +1,3 @@
 extends Tile
 
-func _ready() -> void:
-	super._ready()
-	_set_tile_type("rural_building")
+@export var tile_type: String = "rural_building"

--- a/scripts/Objects/tiles/swamp_tile.gd
+++ b/scripts/Objects/tiles/swamp_tile.gd
@@ -1,5 +1,3 @@
 extends Tile
 
-func _ready() -> void:
-	super._ready()
-	_set_tile_type("swamp")
+@export var tile_type: String = "swamp"

--- a/scripts/Objects/tiles/tile.gd
+++ b/scripts/Objects/tiles/tile.gd
@@ -29,23 +29,13 @@ var overlapping_areas: Array[Area2D] = []
 @onready var sprite: Sprite2D = $Sprite2D
 @onready var collision_shape: CollisionShape2D = $CollisionShape2D
 
-# Terrain costs for trade routes (synced with City.gd)
-const TERRAIN_COSTS: Dictionary = {
-	"fertile": 1.5,
-	"grain": 1.5,
-	"forest": 3.0,
-	"rural_building": 1.0,
-	"road": 1.0,
-	"mine": 2.0,
-	"mountain": 4.0,
-	"swamp": 2.5,
-	"water": 999.0,
-	"unknown": 2.0
-}
+# Terrain costs for trade routes (shared with City.gd)
+const TerrainCosts = preload("res://scripts/Data/terrain_costs.gd")
 
 func _ready() -> void:
-	_initialize_tile()
-	_check_overlaps()
+        _set_tile_type(tile_type)
+        _initialize_tile()
+        _check_overlaps()
 
 func _initialize_tile() -> void:
 	add_to_group("tiles")
@@ -69,10 +59,10 @@ func _check_overlaps() -> void:
 
 func _set_tile_type(new_type: String) -> void:
 	tile_type = new_type
-	if tile_type in TERRAIN_COSTS:
-		movement_cost = TERRAIN_COSTS[tile_type]
+       if tile_type in TerrainCosts.TERRAIN_COSTS:
+               movement_cost = TerrainCosts.TERRAIN_COSTS[tile_type]
 	else:
-		movement_cost = TERRAIN_COSTS["unknown"]
+               movement_cost = TerrainCosts.TERRAIN_COSTS["unknown"]
 		push_warning("Tile type %s not in TERRAIN_COSTS, using default cost" % tile_type)
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:

--- a/scripts/Objects/tiles/water_tile.gd
+++ b/scripts/Objects/tiles/water_tile.gd
@@ -1,5 +1,3 @@
 extends Tile
 
-func _ready() -> void:
-	super._ready()
-	_set_tile_type("water")
+@export var tile_type: String = "water"


### PR DESCRIPTION
## Summary
- centralize terrain costs into `terrain_costs.gd`
- simplify `Tile` setup and tile subclasses
- use shared terrain costs in `City`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68426928e3348320934b0ad73c7b81e8