### PR TITLE
Wire up tile replacement

### DIFF
--- a/scripts/UI/Managers/city_manager.gd
+++ b/scripts/UI/Managers/city_manager.gd
@@ -114,9 +114,10 @@ func find_tile() -> void:
 
 
 func _on_footbar_find_tile_requested() -> void:
-	print("looking for tile")
-	await find_tile() and new_tile_type
-	tile_manager.change_tile_type(selected_tile.global_position, new_tile_type)
+        print("looking for tile")
+        await find_tile()
+        var map_pos: Vector2i = tile_manager.tile_map_layer.local_to_map(selected_tile.global_position)
+        tile_manager.change_tile_type(map_pos, new_tile_type)
 
 
 func _on_tile_manager_tile_clicked_via_manager(tile: Tile) -> void:

--- a/scripts/UI/Managers/tile_manager.gd
+++ b/scripts/UI/Managers/tile_manager.gd
@@ -109,16 +109,17 @@ func change_tile_type(tile_pos:Vector2i, new_type: String) -> bool:
 		print("Failed to load tile scene for:", new_type)
 		return false
 	
-	var new_tile = new_tile_scene.instantiate() as Tile
-	if not new_tile:
-		print("Error to initalize tile for:", new_type)
-		return false
-	
-	new_tile.global_position = tile_state.global_position
-	tile_map_layer.add_child(new_tile)
-	tile_instances[tile_pos] = new_tile
-	print("Tile changed:", tile_pos, new_type)
-	return true
+        var new_tile = new_tile_scene.instantiate() as Tile
+        if not new_tile:
+                print("Error to initalize tile for:", new_type)
+                return false
+
+        new_tile.global_position = tile_state.global_position
+        tile_map_layer.add_child(new_tile)
+        new_tile.tile_clicked.connect(_on_tile_clicked.bind(tile_pos))
+        tile_instances[tile_pos] = new_tile
+        print("Tile changed:", tile_pos, new_type)
+        return true
 
 
 func wait_for_tile_click() -> Tile:


### PR DESCRIPTION
## Summary
- fix tile search flow in `city_manager.gd`
- when replacing a tile, connect the new tile's click signal to the manager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843cf1682a88320847ad5f953df10c7