### PR TITLE
Update tile manager reference

### DIFF
--- a/tile_selection_menu.gd
+++ b/tile_selection_menu.gd
@@ -1,9 +1,9 @@
 extends Control
 
-@onready var tile_manager = $TileManager
+@onready var tile_manager = get_tree().get_root().get_node("GameWorld/TileManager")
 
 func _on_default_button_pressed() -> void:
-	emit_signal("tile_type_received", "default")
+        tile_manager.emit_signal("tile_type_received", "default")
 
 func _on_grain_button_pressed() -> void:
 	tile_manager.emit_signal("tile_type_received", "grain")


### PR DESCRIPTION
## Summary
- locate TileManager via root path
- emit tile type from menu correctly to TileManager

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843cf1acbe48320906f107c100d6c73